### PR TITLE
Maxchehab/ch768/add authorizeurl function to sso module

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
   },
   "dependencies": {
     "axios": "0.19.0",
-    "pluralize": "8.0.0"
+    "pluralize": "8.0.0",
+    "query-string": "6.8.3"
   },
   "devDependencies": {
     "@types/jest": "24.0.17",

--- a/src/audit-log/audit-log.spec.ts
+++ b/src/audit-log/audit-log.spec.ts
@@ -20,7 +20,7 @@ const event = {
 describe('AuditLog', () => {
   describe('createEvent', () => {
     describe('when the api responds with a 201 CREATED', () => {
-      it('posts Event successfuly', async () => {
+      it('posts Event successfully', async () => {
         mock.onPost().reply(201, { success: true });
 
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`SSO getAuthorizeURL with a custom api hostname generates an authorize url with the custom api hostname 1`] = `"https://api.workos.dev/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback"`;
+exports[`SSO getAuthorizationURL with a custom api hostname generates an authorize url with the custom api hostname 1`] = `"https://api.workos.dev/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback"`;
 
-exports[`SSO getAuthorizeURL with no custom api hostname generates an authorize url with the default api hostname 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback"`;
+exports[`SSO getAuthorizationURL with no custom api hostname generates an authorize url with the default api hostname 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback"`;
 
-exports[`SSO getAuthorizeURL with state generates an authorize url the provided state 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&state=custom%20state"`;
+exports[`SSO getAuthorizationURL with state generates an authorize url the provided state 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&state=custom%20state"`;

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -1,0 +1,7 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`SSO getAuthorizeURL with a custom api hostname generates an authorize url with the custom api hostname 1`] = `"https://api.workos.dev/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback"`;
+
+exports[`SSO getAuthorizeURL with no custom api hostname generates an authorize url with the default api hostname 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback"`;
+
+exports[`SSO getAuthorizeURL with state generates an authorize url the provided state 1`] = `"https://api.workos.com/sso/authorize?client_id=proj_123&domain=lyft.com&redirect_uri=example.com%2Fsso%2Fworkos%2Fcallback&state=custom%20state"`;

--- a/src/sso/interfaces/authorize-url-options.interface.ts
+++ b/src/sso/interfaces/authorize-url-options.interface.ts
@@ -1,0 +1,6 @@
+export interface AuthorizeURLOptions {
+  domain: string;
+  projectID: string;
+  redirectURI: string;
+  state?: string;
+}

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -6,7 +6,7 @@ describe('SSO', () => {
       it('generates an authorize url with the default api hostname', () => {
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
-        const url = workos.sso.getAuthorizeURL({
+        const url = workos.sso.authorizeURL({
           domain: 'lyft.com',
           projectID: 'proj_123',
           redirectURI: 'example.com/sso/workos/callback',
@@ -22,7 +22,7 @@ describe('SSO', () => {
           apiHostname: 'api.workos.dev',
         });
 
-        const url = workos.sso.getAuthorizeURL({
+        const url = workos.sso.authorizeURL({
           domain: 'lyft.com',
           projectID: 'proj_123',
           redirectURI: 'example.com/sso/workos/callback',
@@ -36,7 +36,7 @@ describe('SSO', () => {
       it('generates an authorize url the provided state', () => {
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
-        const url = workos.sso.getAuthorizeURL({
+        const url = workos.sso.authorizeURL({
           domain: 'lyft.com',
           projectID: 'proj_123',
           redirectURI: 'example.com/sso/workos/callback',

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -1,0 +1,50 @@
+import WorkOS from '../workos';
+
+describe('SSO', () => {
+  describe('getAuthorizeURL', () => {
+    describe('with no custom api hostname', () => {
+      it('generates an authorize url with the default api hostname', () => {
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+        const url = workos.sso.getAuthorizeURL({
+          domain: 'lyft.com',
+          projectID: 'proj_123',
+          redirectURI: 'example.com/sso/workos/callback',
+        });
+
+        expect(url).toMatchSnapshot();
+      });
+    });
+
+    describe('with a custom api hostname', () => {
+      it('generates an authorize url with the custom api hostname', () => {
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU', {
+          apiHostname: 'api.workos.dev',
+        });
+
+        const url = workos.sso.getAuthorizeURL({
+          domain: 'lyft.com',
+          projectID: 'proj_123',
+          redirectURI: 'example.com/sso/workos/callback',
+        });
+
+        expect(url).toMatchSnapshot();
+      });
+    });
+
+    describe('with state', () => {
+      it('generates an authorize url the provided state', () => {
+        const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+        const url = workos.sso.getAuthorizeURL({
+          domain: 'lyft.com',
+          projectID: 'proj_123',
+          redirectURI: 'example.com/sso/workos/callback',
+          state: 'custom state',
+        });
+
+        expect(url).toMatchSnapshot();
+      });
+    });
+  });
+});

--- a/src/sso/sso.spec.ts
+++ b/src/sso/sso.spec.ts
@@ -1,12 +1,12 @@
 import WorkOS from '../workos';
 
 describe('SSO', () => {
-  describe('getAuthorizeURL', () => {
+  describe('getAuthorizationURL', () => {
     describe('with no custom api hostname', () => {
       it('generates an authorize url with the default api hostname', () => {
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
-        const url = workos.sso.authorizeURL({
+        const url = workos.sso.getAuthorizationURL({
           domain: 'lyft.com',
           projectID: 'proj_123',
           redirectURI: 'example.com/sso/workos/callback',
@@ -22,7 +22,7 @@ describe('SSO', () => {
           apiHostname: 'api.workos.dev',
         });
 
-        const url = workos.sso.authorizeURL({
+        const url = workos.sso.getAuthorizationURL({
           domain: 'lyft.com',
           projectID: 'proj_123',
           redirectURI: 'example.com/sso/workos/callback',
@@ -36,7 +36,7 @@ describe('SSO', () => {
       it('generates an authorize url the provided state', () => {
         const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
 
-        const url = workos.sso.authorizeURL({
+        const url = workos.sso.getAuthorizationURL({
           domain: 'lyft.com',
           projectID: 'proj_123',
           redirectURI: 'example.com/sso/workos/callback',

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -7,7 +7,7 @@ import WorkOS from '../workos';
 export class SSO {
   constructor(private readonly workos: WorkOS) {}
 
-  authorizeURL({
+  getAuthorizationURL({
     domain,
     projectID,
     redirectURI,

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -1,5 +1,27 @@
+import queryString from 'query-string';
+
+import { API_HOSTNAME } from '../common/constants';
+import { AuthorizeURLOptions } from './interfaces/authorize-url-options.interface';
 import WorkOS from '../workos';
 
 export class SSO {
   constructor(private readonly workos: WorkOS) {}
+
+  getAuthorizeURL({
+    domain,
+    projectID,
+    redirectURI,
+    state,
+  }: AuthorizeURLOptions): string {
+    const { apiHostname = API_HOSTNAME } = this.workos.options;
+
+    const query = queryString.stringify({
+      domain,
+      client_id: projectID,
+      redirect_uri: redirectURI,
+      state,
+    });
+
+    return `https://${apiHostname}/sso/authorize?${query}`;
+  }
 }

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -7,7 +7,7 @@ import WorkOS from '../workos';
 export class SSO {
   constructor(private readonly workos: WorkOS) {}
 
-  getAuthorizeURL({
+  authorizeURL({
     domain,
     projectID,
     redirectURI,

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -1,0 +1,5 @@
+import WorkOS from '../workos';
+
+export class SSO {
+  constructor(private readonly workos: WorkOS) {}
+}

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -9,17 +9,16 @@ import {
   UnauthorizedException,
   UnprocessableEntityException,
 } from './common/exceptions';
+import { SSO } from './sso/sso';
 import { version } from '../package.json';
 import { WorkOSOptions } from './common/interfaces';
 
 // tslint:disable-next-line:no-default-export
 export default class WorkOS {
   readonly auditLog = new AuditLog(this);
+  readonly sso = new SSO(this);
 
-  constructor(
-    private readonly key?: string,
-    private readonly options: WorkOSOptions = {},
-  ) {
+  constructor(readonly key?: string, readonly options: WorkOSOptions = {}) {
     if (!key) {
       this.key = process.env.WORKOS_API_KEY;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2937,6 +2937,15 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@6.8.3:
+  version "6.8.3"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.8.3.tgz#fd9fb7ffb068b79062b43383685611ee47777d4b"
+  integrity sha512-llcxWccnyaWlODe7A9hRjkvdCKamEKTh+wH8ITdTc3OhchaqUZteiSCX/2ablWHVrkVIe04dntnaZJ7BdyW0lQ==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 rc@^1.0.1, rc@^1.1.6, rc@^1.2.7:
   version "1.2.8"
   resolved "https://registry.yarnpkg.com/rc/-/rc-1.2.8.tgz#cd924bf5200a075b83c188cd6b9e211b7fc0d3ed"
@@ -3324,6 +3333,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz#75ecd1a88de8c184ef015eafb51b5b48bfd11bb1"
   integrity sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/split-string/-/split-string-3.1.0.tgz#7cb09dda3a86585705c64b39a6466038682e8fe2"
@@ -3368,6 +3382,11 @@ stealthy-require@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
   integrity sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
This PR:
- Adds an SSO module to the SDK
	- It can be accessed by `new WorkOS().sso`
- Adds an `sso.getAuthorizationURL` which interpolates provided, `domain`, `projectID`, and `redirectURI`, along with using the optional `apiHostname` configuration, that generate a url to initiates our Oauth2 flow.
- Converts `WorkOS.key` and `WorkOS.options` from `private readonly` to just `readonly` so that submodules can reference their properties. 