### PR TITLE
fix version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.0.4",
+  "version": "0.0.23",
   "name": "@workos-inc/js",
   "author": "WorkOS",
   "description": "A wrapper for the WorkOS API for all things javascript.",

--- a/src/sso/__snapshots__/sso.spec.ts.snap
+++ b/src/sso/__snapshots__/sso.spec.ts.snap
@@ -13,7 +13,7 @@ Object {
   "Accept": "application/json, text/plain, */*",
   "Authorization": "Bearer sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU",
   "Content-Type": "application/x-www-form-urlencoded",
-  "User-Agent": "workos-js/0.0.4",
+  "User-Agent": "workos-js/0.0.23",
 }
 `;
 


### PR DESCRIPTION
Our latest published version is actually 0.0.22 but package.json had 0.0.3...

https://www.npmjs.com/package/@workos-inc/js?activeTab=versions