### PR TITLE
Delete authorize-url-options.interface.ts

### DIFF
--- a/src/sso/interfaces/authorize-url-options.interface.ts
+++ b/src/sso/interfaces/authorize-url-options.interface.ts
@@ -1,6 +1,0 @@
-export interface AuthorizeURLOptions {
-  domain: string;
-  projectID: string;
-  redirectURI: string;
-  state?: string;
-}


### PR DESCRIPTION
We weren't using this interface anywhere. Thing this happened with a stray rebase / file rename.