### PR TITLE
Maxchehab/ch1326/node implement idempotency key header for

### DIFF
--- a/src/audit-log/audit-log.spec.ts
+++ b/src/audit-log/audit-log.spec.ts
@@ -20,6 +20,24 @@ const event = {
 describe('AuditLog', () => {
   describe('createEvent', () => {
     describe('when the api responds with a 201 CREATED', () => {
+      describe('with an idempotency key', () => {
+        it('includes an idempotency key with request', async () => {
+          mock.onPost().reply(201, { success: true });
+
+          const workos = new WorkOS('sk_test_Sz3IQjepeSWaI4cMS4ms4sMuU');
+
+          await expect(
+            workos.auditLog.createEvent(event, {
+              idempotencyKey: 'the-idempotency-key',
+            }),
+          ).resolves.toBeUndefined();
+
+          expect(mock.history.post[0].headers['Idempotency-Key']).toEqual(
+            'the-idempotency-key',
+          );
+        });
+      });
+
       it('posts Event successfully', async () => {
         mock.onPost().reply(201, { success: true });
 

--- a/src/audit-log/audit-log.ts
+++ b/src/audit-log/audit-log.ts
@@ -6,12 +6,6 @@ export class AuditLog {
   constructor(private readonly workos: WorkOS) {}
 
   async createEvent(event: Event, { idempotencyKey }: CreateEventOptions = {}) {
-    const headers: any = {};
-
-    if (idempotencyKey) {
-      headers['Idempotency-Key'] = idempotencyKey;
-    }
-
-    await this.workos.post('/events', event, { headers });
+    await this.workos.post('/events', event, { idempotencyKey });
   }
 }

--- a/src/audit-log/audit-log.ts
+++ b/src/audit-log/audit-log.ts
@@ -1,10 +1,17 @@
+import { CreateEventOptions } from './interfaces/create-event-options.interface';
 import { Event } from '../common/interfaces';
 import WorkOS from '../workos';
 
 export class AuditLog {
   constructor(private readonly workos: WorkOS) {}
 
-  async createEvent(event: Event) {
-    await this.workos.post('/events', event);
+  async createEvent(event: Event, { idempotencyKey }: CreateEventOptions = {}) {
+    const headers: any = {};
+
+    if (idempotencyKey) {
+      headers['Idempotency-Key'] = idempotencyKey;
+    }
+
+    await this.workos.post('/events', event, { headers });
   }
 }

--- a/src/audit-log/interfaces/create-event-options.interface.ts
+++ b/src/audit-log/interfaces/create-event-options.interface.ts
@@ -1,0 +1,3 @@
+export interface CreateEventOptions {
+  idempotencyKey?: string;
+}

--- a/src/common/interfaces/index.ts
+++ b/src/common/interfaces/index.ts
@@ -2,3 +2,4 @@ export { Event } from './event.interface';
 export { HttpException } from './http-exception.interface';
 export { UnprocessableEntityError } from './unprocessable-entity-error.interface';
 export { WorkOSOptions } from './workos-options.interface';
+export { PostOptions } from './post-options.interface';

--- a/src/common/interfaces/post-options.interface.ts
+++ b/src/common/interfaces/post-options.interface.ts
@@ -1,0 +1,4 @@
+export interface PostOptions {
+  query?: { [key: string]: any };
+  headers?: { [key: string]: any };
+}

--- a/src/common/interfaces/post-options.interface.ts
+++ b/src/common/interfaces/post-options.interface.ts
@@ -1,4 +1,4 @@
 export interface PostOptions {
   query?: { [key: string]: any };
-  headers?: { [key: string]: any };
+  idempotencyKey?: string;
 }

--- a/src/sso/sso.ts
+++ b/src/sso/sso.ts
@@ -27,10 +27,12 @@ export class SSO {
 
   async getProfile({ code, projectID }: GetProfileOptions): Promise<Profile> {
     const { data } = await this.workos.post('/sso/token', null, {
-      client_id: projectID,
-      client_secret: this.workos.key,
-      grant_type: 'authorization_code',
-      code,
+      query: {
+        client_id: projectID,
+        client_secret: this.workos.key,
+        grant_type: 'authorization_code',
+        code,
+      },
     });
 
     return data.profile as Profile;

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -57,10 +57,16 @@ export class WorkOS {
     entity: any,
     options: PostOptions = {},
   ): Promise<AxiosResponse> {
+    const requestHeaders: any = {};
+
+    if (options.idempotencyKey) {
+      requestHeaders['Idempotency-Key'] = options.idempotencyKey;
+    }
+
     try {
       return await this.client.post(path, entity, {
         params: options.query,
-        headers: options.headers,
+        headers: requestHeaders,
       });
     } catch (error) {
       const { response } = error as AxiosError;

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -10,7 +10,7 @@ import {
 } from './common/exceptions';
 import { SSO } from './sso/sso';
 import { version } from '../package.json';
-import { WorkOSOptions } from './common/interfaces';
+import { WorkOSOptions, PostOptions } from './common/interfaces';
 
 const DEFAULT_HOSTNAME = 'api.workos.com';
 
@@ -52,9 +52,13 @@ export class WorkOS {
     });
   }
 
-  async post(path: string, entity: any, query?: any): Promise<AxiosResponse> {
+  async post(
+    path: string,
+    entity: any,
+    { query, headers }: PostOptions = {},
+  ): Promise<AxiosResponse> {
     try {
-      return await this.client.post(path, entity, { params: query });
+      return await this.client.post(path, entity, { params: query, headers });
     } catch (error) {
       const { response } = error as AxiosError;
 

--- a/src/workos.ts
+++ b/src/workos.ts
@@ -55,10 +55,13 @@ export class WorkOS {
   async post(
     path: string,
     entity: any,
-    { query, headers }: PostOptions = {},
+    options: PostOptions = {},
   ): Promise<AxiosResponse> {
     try {
-      return await this.client.post(path, entity, { params: query, headers });
+      return await this.client.post(path, entity, {
+        params: options.query,
+        headers: options.headers,
+      });
     } catch (error) {
       const { response } = error as AxiosError;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "noUnusedParameters": true,
     "resolveJsonModule": true,
     "typeRoots": ["./node_modules/@types"],
-    "target": "esnext",
+    "target": "es6",
     "module": "commonjs",
     "declaration": true,
     "outDir": "./dist",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1228,7 +1228,12 @@ fast-deep-equal@^2.0.1:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
   integrity sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=
 
-fast-json-stable-stringify@2.x, fast-json-stable-stringify@^2.0.0:
+fast-json-stable-stringify@2.x:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
+  integrity sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+
+fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
   integrity sha1-1RQsDK7msRifh9OnYREGT4bIu/I=
@@ -2241,7 +2246,14 @@ json-stringify-safe@~5.0.1:
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
-json5@2.x, json5@^2.1.0:
+json5@2.x:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.1.tgz#81b6cb04e9ba496f1c7005d07b4368a2638f90b6"
+  integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
+  dependencies:
+    minimist "^1.2.0"
+
+json5@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.0.tgz#e7a0c62c48285c628d20a10b85c89bb807c32850"
   integrity sha512-8Mh9h6xViijj36g7Dxi+Y4S6hNGV96vcJZr/SrlHh1LR/pEn/8j/+qIBbs44YKl69Lrfctp4QD+AdWLTMqEZAQ==
@@ -3115,7 +3127,14 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.x, resolve@^1.10.0, resolve@^1.3.2:
+resolve@1.x:
+  version "1.14.2"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.14.2.tgz#dbf31d0fa98b1f29aa5169783b9c290cb865fea2"
+  integrity sha512-EjlOBLBO1kxsUxsKjLt7TAECyKW6fOh1VRkykQkKGzcBbjjPIxBqGh0jf7GJ3k/f5mxMqW3htMD3WdTUVtW8HQ==
+  dependencies:
+    path-parse "^1.0.6"
+
+resolve@^1.10.0, resolve@^1.3.2:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.0.tgz#4014870ba296176b86343d50b60f3b50609ce232"
   integrity sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==
@@ -3176,10 +3195,15 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.0.tgz#790a7cf6fea5459bac96110b29b60412dc8ff96b"
   integrity sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==
+
+semver@^5.5:
+  version "5.7.1"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
 semver@^6.0.0:
   version "6.1.1"


### PR DESCRIPTION
This PR lets the developer attach a custom `Idempotency-Key` header to `POST /events`.

This feature is exposed by an optional parameter in the `createEvent` method. Ex: 
```ts
workos.auditLog.createEvent(event, {
  idempotencyKey: 'an-idempotency-key',
}),
```